### PR TITLE
Fix minor UI inconsistencies with date formats & genesis proposer names

### DIFF
--- a/static/js/page-index.js
+++ b/static/js/page-index.js
@@ -12,7 +12,11 @@
   var baseModel = {
     formatAddCommas: function(x) { return x; },
     unixtime: function(x) { return Math.floor(new Date(x).getTime() / 1000); },
-    timestamp: function(x) { return x; },
+    timestamp: function(x) { 
+      var d = new Date(x);
+      var p = /^([0-9-]+)T([0-9:]+).[0-9]+Z$/.exec(d.toISOString());
+      return p[1] + " " + p[2] + " +0000 UTC";
+    },
     formatRecentTimeShort: function(x) { return window.explorer.renderRecentTime(Math.floor(new Date(x).getTime() / 1000)); },
     formatEth: function(x) { return formatFloat(x / 1000000000, 4); },
     formatFloat: function(x) { return formatFloat(x, 2); },

--- a/templates/epoch/epoch.html
+++ b/templates/epoch/epoch.html
@@ -188,7 +188,7 @@
                     {{ end }}
                   </td>
                   <td data-timer="{{ $slot.Ts.Unix }}"><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $slot.Ts }}">{{ formatRecentTimeShort $slot.Ts }}</span></td>
-                  <td>{{ formatValidator $slot.Proposer $slot.ProposerName }}</td>
+                  <td>{{ if gt $slot.Slot 0 }}{{ formatValidator $slot.Proposer $slot.ProposerName }}{{ end }}</td>
                   {{ if $epoch.Synchronized }}
                     <td class="d-none d-md-table-cell">{{ if not (eq $slot.Status 0) }}{{ $slot.AttestationCount }}{{ end }}</td>
                     <td>{{ if not (eq $slot.Status 0) }}{{ $slot.DepositCount }} / {{ $slot.ExitCount }}{{ end }}</td>

--- a/templates/index/networkOverview.html
+++ b/templates/index/networkOverview.html
@@ -80,9 +80,9 @@
         <div class="col-md-2"><span data-bs-toggle="tooltip" data-bs-placement="top" title="Name of the Network">Genesis Time:</span></div>
         <div class="col-md-10">
           <div>
-            <span aria-ethereum-date="{{ .GenesisTime.Unix }}" aria-ethereum-date-format="FROMNOW" data-bind="attr: {'aria-ethereum-date': $root.unixtime(genesis_time())}, text: genesis_time()">{{ .GenesisTime }}</span>
+            <span aria-ethereum-date="{{ .GenesisTime.Unix }}" aria-ethereum-date-format="FROMNOW" data-bind="attr: {'aria-ethereum-date': $root.unixtime(genesis_time())}, text: $root.timestamp(genesis_time())">{{ .GenesisTime.UTC }}</span>
             (<span id="timestamp" aria-ethereum-date="{{ .GenesisTime.Unix }}" aria-ethereum-date-format="LOCAL" data-timer="{{ .GenesisTime.Unix }}" data-bind="attr: {'aria-ethereum-date': $root.unixtime(genesis_time()), 'data-timer': $root.unixtime(genesis_time())}, text: $root.formatRecentTimeShort(genesis_time())">{{ formatRecentTimeShort .GenesisTime }}</span>)
-            <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ .GenesisTime }}" data-bind="attr: {'data-clipboard-text': genesis_time()}"></i>
+            <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ .GenesisTime.UTC }}" data-bind="attr: {'data-clipboard-text': genesis_time()}"></i>
           </div>
         </div>
       </div>

--- a/templates/index/networkOverview.html
+++ b/templates/index/networkOverview.html
@@ -82,7 +82,7 @@
           <div>
             <span aria-ethereum-date="{{ .GenesisTime.Unix }}" aria-ethereum-date-format="FROMNOW" data-bind="attr: {'aria-ethereum-date': $root.unixtime(genesis_time())}, text: $root.timestamp(genesis_time())">{{ .GenesisTime.UTC }}</span>
             (<span id="timestamp" aria-ethereum-date="{{ .GenesisTime.Unix }}" aria-ethereum-date-format="LOCAL" data-timer="{{ .GenesisTime.Unix }}" data-bind="attr: {'aria-ethereum-date': $root.unixtime(genesis_time()), 'data-timer': $root.unixtime(genesis_time())}, text: $root.formatRecentTimeShort(genesis_time())">{{ formatRecentTimeShort .GenesisTime }}</span>)
-            <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ .GenesisTime.UTC }}" data-bind="attr: {'data-clipboard-text': genesis_time()}"></i>
+            <i class="fa fa-copy text-muted p-1" role="button" data-bs-toggle="tooltip" title="Copy to clipboard" data-clipboard-text="{{ .GenesisTime.UTC }}" data-bind="attr: {'data-clipboard-text': $root.timestamp(genesis_time())}"></i>
           </div>
         </div>
       </div>

--- a/templates/index/recentSlots.html
+++ b/templates/index/recentSlots.html
@@ -49,7 +49,11 @@
               <td data-bind="attr: {'data-timer': $root.unixtime(ts)}">
                 <span data-bs-toggle="tooltip" data-bs-placement="top" data-bind="attr: {'data-bs-title': $root.timestamp(ts)}, text: $root.formatRecentTimeShort(ts)"></span>
               </td>
-              <td data-bind="html: $root.formatValidator(proposer, proposer_name)"></td>
+              <td>
+                <span data-bind="if: slot > 0">
+                  <span data-bind="html: $root.formatValidator(proposer, proposer_name)"></span>
+                </span>
+              </td>
             </tr>
             {{ html "<!-- /ko -->" }}
             {{ html "<!-- ko if: slots().length == 0 -->" }}

--- a/templates/slots/slots.html
+++ b/templates/slots/slots.html
@@ -107,7 +107,7 @@
                     </td>
                     <td data-timer="{{ $slot.Ts.Unix }}"><span data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="{{ $slot.Ts }}">{{ formatRecentTimeShort $slot.Ts }}</span></td>
                     {{ if $slot.Synchronized }}
-                      <td>{{ formatValidator $slot.Proposer $slot.ProposerName }}</td>
+                      <td>{{ if gt $slot.Slot 0 }}{{ formatValidator $slot.Proposer $slot.ProposerName }}{{ end }}</td>
                       <td class="d-none d-md-table-cell">{{ if not (eq $slot.Status 0) }}{{ $slot.AttestationCount }}{{ end }}</td>
                       <td>{{ if not (eq $slot.Status 0) }}{{ $slot.DepositCount }} / {{ $slot.ExitCount }}{{ end }}</td>
                       <td>{{ if not (eq $slot.Status 0) }}{{ $slot.ProposerSlashingCount }} / {{ $slot.AttesterSlashingCount }}{{ end }}</td>


### PR DESCRIPTION
Fixed minor UI inconsistencies with dynamic refresh on startpage:
![image](https://github.com/pk910/dora-the-explorer/assets/491045/47ae2590-d81e-4ef0-a610-16e6a67ccb6c)
![image](https://github.com/pk910/dora-the-explorer/assets/491045/0e29b570-fcf9-4a1a-b547-75bc583feaf6)

Also fixed showing proposer name for genesis block in various views